### PR TITLE
Allow version 2 of `doctrine-orm-module`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "zendframework/zend-modulemanager": "~2.0",
-        "zendframework/zend-eventmanager": "~3.0",
-        "zendframework/zend-servicemanager": "~3.0",
+        "php": "^5.5.9 || ^7.0",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/doctrine-orm-module": "^1.1"
+        "doctrine/doctrine-orm-module": "^1.1 || ^2.0",
+        "zendframework/zend-eventmanager": "~3.0",
+        "zendframework/zend-modulemanager": "~2.0",
+        "zendframework/zend-servicemanager": "~3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hello,

I've tested this packages with `doctrine-orm-module version 2. It's working, but I didn't expect it to be not, since the code isn't directly depending on the DoctrineORMModule code.